### PR TITLE
README: Add excerpt regarding Clang compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,11 @@
 These are my personal scripts for various tasks (which are talked about briefly at the top of every script).
 
 Feel free to take and use as you see fit!
+
+To build Clang, you will need to the following:
+
++ A Linux distribution (the script has been tested on Ubuntu 17.04 and Arch Linux)
++ A decent processor and RAM (i5 and 8GB of RAM or more is preferred)
++ Core developer packages
+    + For Arch: the base-devel package should be enough
+    + For Ubuntu: ```sudo apt-get install flex bison ncurses-dev texinfo gcc gperf patch libtool automake g++ libncurses5-dev gawk subversion expat libexpat1-dev python-all-dev binutils-dev libgcc1:i386 bc libcloog-isl-dev libcap-dev autoconf libgmp-dev build-essential gcc-multilib g++-multilib pkg-config libmpc-dev libmpfr-dev```


### PR DESCRIPTION
This adds excellent clarification for the required tools in order to
compile clang.

The excerpt was pulled from here:
https://raw.githubusercontent.com/nathanchance/build-tools-gcc/master/README.md